### PR TITLE
Expose SQLite WAL files to dashboard backend

### DIFF
--- a/dashboard/docker-compose.yml
+++ b/dashboard/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "5000"
     volumes:
-      - /var/www/html/strom.sqlite:/app/data/strom.sqlite
+      - /var/www/html:/app/data:ro
     networks:
       - strom-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: ghcr.io/sasue/raspi-stromreader/dashboard-backend:latest
     container_name: strom-dashboard-backend
     volumes:
-      - /var/www/html/strom.sqlite:/app/data/strom.sqlite
+      - /var/www/html:/app/data:ro
     networks:
       - proxy-net
 
@@ -31,4 +31,3 @@ services:
 networks:
   proxy-net:
     external: true
-


### PR DESCRIPTION
## Zusammenfassung

- bindet das vollständige SQLite-Datenverzeichnis schreibgeschützt in das Backend ein
- macht strom.sqlite-wal und strom.sqlite-shm für lesende Backend-Verbindungen sichtbar
- korrigiert sowohl die produktive als auch die Dashboard-Compose-Datei

## Ursache

Seit Version 1.1.3 schreibt SQLite im WAL-Modus. Der bisherige Einzeldatei-Mount stellte dem Backend nur strom.sqlite bereit, nicht aber die aktuellen Änderungen in strom.sqlite-wal. Dadurch lieferte die API veraltete Werte.

## Validierung

- Live-Datenbank und API liefern denselben aktuellen Zeitstempel
- Backend-Mount ist read-only
- Dashboard und API liefern HTTP 200
- 12 Tests erfolgreich
- beide Compose-Dateien sind gültiges YAML.