### PR TITLE
Add Docker health checks for reader and backend

### DIFF
--- a/dashboard/dashboard-backend/Dockerfile
+++ b/dashboard/dashboard-backend/Dockerfile
@@ -6,5 +6,8 @@ RUN pip install --upgrade pip
 RUN pip install flask
 
 COPY dashboard-backend.py /app/dashboard-backend.py
+COPY healthcheck.py /app/healthcheck.py
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD ["python3", "/app/healthcheck.py"]
 CMD ["python3", "/app/dashboard-backend.py"] 

--- a/dashboard/dashboard-backend/healthcheck.py
+++ b/dashboard/dashboard-backend/healthcheck.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Docker health check for the dashboard backend."""
+
+import json
+import os
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+HEALTH_URL = os.getenv(
+    "BACKEND_HEALTH_URL", "http://127.0.0.1:5000/api/dashboard"
+)
+TIMEOUT_SECONDS = float(os.getenv("BACKEND_HEALTH_TIMEOUT_SECONDS", "5"))
+
+
+def check_health(url=HEALTH_URL):
+    try:
+        with urlopen(url, timeout=TIMEOUT_SECONDS) as response:
+            if response.status != 200:
+                return False, f"backend returned HTTP {response.status}"
+            payload = json.load(response)
+
+        if not isinstance(payload, dict) or "timestamp" not in payload:
+            return False, "backend returned an unexpected response"
+        if payload.get("error"):
+            return False, f"backend error: {payload['error']}"
+        return True, "backend API is responding"
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, OSError) as error:
+        return False, f"backend check failed: {error}"
+
+
+def main():
+    healthy, message = check_health()
+    print(message)
+    return 0 if healthy else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reader/Dockerfile
+++ b/reader/Dockerfile
@@ -7,5 +7,8 @@ RUN pip install pyserial crcmod
 
 COPY strom_reader.py /app/strom_reader.py
 COPY sqlite_store.py /app/sqlite_store.py
+COPY healthcheck.py /app/healthcheck.py
 
+HEALTHCHECK --interval=60s --timeout=15s --start-period=5m --retries=3 \
+    CMD ["python3", "/app/healthcheck.py"]
 CMD ["python3", "/app/strom_reader.py"]

--- a/reader/healthcheck.py
+++ b/reader/healthcheck.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Docker health check for the meter reader."""
+
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+
+DB_PATH = Path(os.getenv("DB_PATH", "/app/data/strom.sqlite"))
+MAX_AGE_SECONDS = int(os.getenv("READER_HEALTH_MAX_AGE_SECONDS", "180"))
+FUTURE_TOLERANCE_SECONDS = int(
+    os.getenv("READER_HEALTH_FUTURE_TOLERANCE_SECONDS", "60")
+)
+LOCAL_TIMEZONE = ZoneInfo(os.getenv("TZ", "Europe/Berlin"))
+
+
+def newest_measurement(db_path=DB_PATH):
+    uri = f"{Path(db_path).resolve().as_uri()}?mode=ro"
+    with sqlite3.connect(uri, uri=True, timeout=5) as connection:
+        row = connection.execute(
+            "SELECT MAX(timestamp) FROM messwerte"
+        ).fetchone()
+    return row[0] if row else None
+
+
+def parse_timestamp(value):
+    timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=LOCAL_TIMEZONE)
+    return timestamp.astimezone(timezone.utc)
+
+
+def check_health(db_path=DB_PATH, now=None):
+    try:
+        value = newest_measurement(db_path)
+        if not value:
+            return False, "no measurements in database"
+
+        current_time = now or datetime.now(timezone.utc)
+        age = (current_time - parse_timestamp(value)).total_seconds()
+        if age < -FUTURE_TOLERANCE_SECONDS:
+            return False, f"newest measurement is {-age:.0f}s in the future"
+        if age > MAX_AGE_SECONDS:
+            return False, f"newest measurement is {age:.0f}s old"
+        return True, f"newest measurement is {max(age, 0):.0f}s old"
+    except (OSError, sqlite3.Error, TypeError, ValueError) as error:
+        return False, f"database check failed: {error}"
+
+
+def main():
+    healthy, message = check_health()
+    print(message)
+    return 0 if healthy else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_healthchecks.py
+++ b/tests/test_healthchecks.py
@@ -1,0 +1,116 @@
+import importlib.util
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+reader_health = load_module("reader_health", ROOT / "reader" / "healthcheck.py")
+backend_health = load_module(
+    "backend_health",
+    ROOT / "dashboard" / "dashboard-backend" / "healthcheck.py",
+)
+
+
+class ReaderHealthcheckTest(unittest.TestCase):
+    def create_database(self, timestamp=None):
+        temporary_directory = tempfile.TemporaryDirectory()
+        database = Path(temporary_directory.name) / "strom.sqlite"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE messwerte (timestamp TEXT NOT NULL)"
+            )
+            if timestamp:
+                connection.execute(
+                    "INSERT INTO messwerte (timestamp) VALUES (?)",
+                    (timestamp,),
+                )
+        return temporary_directory, database
+
+    def test_recent_measurement_is_healthy(self):
+        now = datetime.now(timezone.utc)
+        temporary_directory, database = self.create_database(
+            (now - timedelta(seconds=30)).isoformat()
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        healthy, _ = reader_health.check_health(database, now=now)
+
+        self.assertTrue(healthy)
+
+    def test_stale_measurement_is_unhealthy(self):
+        now = datetime.now(timezone.utc)
+        temporary_directory, database = self.create_database(
+            (now - timedelta(seconds=600)).isoformat()
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        healthy, message = reader_health.check_health(database, now=now)
+
+        self.assertFalse(healthy)
+        self.assertIn("old", message)
+
+    def test_naive_local_timestamp_is_supported(self):
+        now = datetime.now(timezone.utc)
+        local_timestamp = (
+            now.astimezone(reader_health.LOCAL_TIMEZONE)
+            - timedelta(seconds=30)
+        ).replace(tzinfo=None)
+        temporary_directory, database = self.create_database(
+            local_timestamp.isoformat()
+        )
+        self.addCleanup(temporary_directory.cleanup)
+
+        healthy, _ = reader_health.check_health(database, now=now)
+
+        self.assertTrue(healthy)
+
+    def test_missing_database_is_unhealthy(self):
+        healthy, _ = reader_health.check_health("/does/not/exist.sqlite")
+
+        self.assertFalse(healthy)
+
+
+class FakeResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, *_args):
+        return b'{"timestamp": "2026-01-01T00:00:00+00:00"}'
+
+
+class BackendHealthcheckTest(unittest.TestCase):
+    @patch.object(backend_health, "urlopen", return_value=FakeResponse())
+    def test_valid_api_response_is_healthy(self, _urlopen):
+        healthy, _ = backend_health.check_health()
+
+        self.assertTrue(healthy)
+
+    @patch.object(backend_health, "urlopen")
+    def test_unreachable_api_is_unhealthy(self, urlopen):
+        urlopen.side_effect = backend_health.URLError("unreachable")
+
+        healthy, _ = backend_health.check_health()
+
+        self.assertFalse(healthy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Was wurde geändert?

- Der Reader prüft die SQLite-Datenbank read-only auf aktuelle Messwerte.
- Das Backend prüft seinen lokalen Dashboard-API-Endpunkt und die Antwortstruktur.
- Beide Dockerfiles enthalten passende `HEALTHCHECK`-Anweisungen.
- Reader-Migrationen werden durch eine fünfminütige Startphase berücksichtigt.
- Automatisierte Tests decken gesunde und fehlerhafte Zustände ab.

## Nutzen

Docker und nachgelagerte Überwachung erkennen nun nicht nur laufende Prozesse, sondern auch einen Reader ohne neue Daten beziehungsweise ein nicht funktionsfähiges Backend.

## Validierung

- `python -m unittest discover -s tests -v`: 18 Tests erfolgreich
- `python -m py_compile reader/healthcheck.py dashboard/dashboard-backend/healthcheck.py`
- `git diff --check`

Closes #44
Closes #45